### PR TITLE
XFAV-32:Favourites are wrongly listed when pages have rights limitations

### DIFF
--- a/application-favorites-ui/src/main/resources/Favorites/Code/FavoritesMacro.xml
+++ b/application-favorites-ui/src/main/resources/Favorites/Code/FavoritesMacro.xml
@@ -273,7 +273,7 @@ No parameters are currently supported.
 #if ($favoritePages &amp;&amp; $favoritePages.size() &gt; 0)
   #foreach($f in $favoritePages)
     #set($fDoc = $xwiki.getDocument($f))
-    #if(!$fDoc.isNew())
+    #if(!$fDoc.isNew() &amp;&amp; !$objecttool.isNull($fDoc) &amp;&amp; $services.security.authorization.hasAccess('view', $fDoc.documentReference))
       * [[$services.rendering.escape($services.rendering.escape($fDoc.plainTitle, 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($fDoc.prefixedFullName, 'xwiki/2.1')]]
     #end
   #end

--- a/application-favorites-ui/src/main/resources/Favorites/Code/FavoritesUserProfileUIX.xml
+++ b/application-favorites-ui/src/main/resources/Favorites/Code/FavoritesUserProfileUIX.xml
@@ -129,7 +129,7 @@
 #if ($favoritePages &amp;&amp; $favoritePages.size() &gt; 0)
   #foreach($f in $favoritePages)
     #set($fDoc = $xwiki.getDocument($f))
-    #if(!$fDoc.isNew())
+    #if(!$fDoc.isNew() &amp;&amp; !$objecttool.isNull($fDoc) &amp;&amp; $services.security.authorization.hasAccess('view', $fDoc.documentReference))
       * [[$services.rendering.escape($services.rendering.escape($fDoc.plainTitle, 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($fDoc.prefixedFullName, 'xwiki/2.1')]]
     #end
   #end


### PR DESCRIPTION
Just add a check that the user have the rights to see the page before trying to list the element.

In my opinion this is the correct fix as we have the same behavior in the document tree macro, only the pages that the user can see are listed.